### PR TITLE
[Coinbase] operators addition

### DIFF
--- a/operators/coinbase1/metadata.json
+++ b/operators/coinbase1/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Coinbase [1]",
+  "website": "https://www.coinbase.com/staking",
+  "description": "Coinbase maintains world-class, enterprise-grade staking infrastructure across multiple networks with zero slashing events and a 99% uptime guarantee.",
+  "logo": "https://raw.githubusercontent.com/layr-labs/eigendata/master/operators/coinbasecloud/logo.png",
+  "twitter": "https://twitter.com/CoinbaseDev"
+}

--- a/operators/coinbase2/metadata.json
+++ b/operators/coinbase2/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Coinbase [2]",
+  "website": "https://www.coinbase.com/staking",
+  "description": "Coinbase maintains world-class, enterprise-grade staking infrastructure across multiple networks with zero slashing events and a 99% uptime guarantee.",
+  "logo": "https://raw.githubusercontent.com/layr-labs/eigendata/master/operators/coinbasecloud/logo.png",
+  "twitter": "https://twitter.com/CoinbaseDev"
+}

--- a/operators/coinbase3/metadata.json
+++ b/operators/coinbase3/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Coinbase [3]",
+  "website": "https://www.coinbase.com/staking",
+  "description": "Coinbase maintains world-class, enterprise-grade staking infrastructure across multiple networks with zero slashing events and a 99% uptime guarantee.",
+  "logo": "https://raw.githubusercontent.com/layr-labs/eigendata/master/operators/coinbasecloud/logo.png",
+  "twitter": "https://twitter.com/CoinbaseDev"
+}

--- a/operators/coinbase4/metadata.json
+++ b/operators/coinbase4/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Coinbase [4]",
+  "website": "https://www.coinbase.com/staking",
+  "description": "Coinbase maintains world-class, enterprise-grade staking infrastructure across multiple networks with zero slashing events and a 99% uptime guarantee.",
+  "logo": "https://raw.githubusercontent.com/layr-labs/eigendata/master/operators/coinbasecloud/logo.png",
+  "twitter": "https://twitter.com/CoinbaseDev"
+}

--- a/operators/coinbase5/metadata.json
+++ b/operators/coinbase5/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Coinbase [5]",
+  "website": "https://www.coinbase.com/staking",
+  "description": "Coinbase maintains world-class, enterprise-grade staking infrastructure across multiple networks with zero slashing events and a 99% uptime guarantee.",
+  "logo": "https://raw.githubusercontent.com/layr-labs/eigendata/master/operators/coinbasecloud/logo.png",
+  "twitter": "https://twitter.com/CoinbaseDev"
+}


### PR DESCRIPTION
Operator metadata for 5 eigenlayer node operators. They all share the same logo.png file in the existing operators/coinbasecloud directory.