### PR TITLE
typo fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Contains Operator and AVS metadata
 
 ### Steps
 1. Fork this repo.
-1. Create a folder with a unique name in appropriate folder(operator/avs). This could be your organization or anything which identies your operator or avs.
+1. Create a folder with a unique name in appropriate folder(operator/avs). This could be your organization or anything which identities your operator or avs.
 3. Add `metadata.json` and `logo.png` and make sure the logo url in `metadata.json` is correct.
 4. Create a PR with this.
 5. We will review and merge. After that feel free to use that in your operations.


### PR DESCRIPTION
**Title**:  
Typo fix: README.md

**Description**:  
Corrected a typo in `README.md`, changing **"identies"** to **"identifies"** for correct spelling and clarity.
